### PR TITLE
Fix creation of empty translations on update on a new locale

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       nokogiri (>= 1.5.10)
       rake
       rdoc
-    json (1.8.1)
+    json (1.8.6)
     jwt (1.0.0)
     mini_portile (0.6.0)
     minitest (5.4.0)
@@ -78,3 +78,6 @@ DEPENDENCIES
   minitest
   puret!
   sqlite3
+
+BUNDLED WITH
+   2.0.2

--- a/lib/puret/active_record_extensions.rb
+++ b/lib/puret/active_record_extensions.rb
@@ -26,6 +26,7 @@ module Puret
           # attribute setter
           define_method "#{attribute}=" do |value|
             current_locale = has_unique_locale? ? locale.to_sym : I18n.locale
+            puret_attributes[current_locale] ||= {}
             puret_attributes[current_locale][attribute] = value
           end
 
@@ -33,7 +34,8 @@ module Puret
           define_method attribute do
             # return previously setted attributes if present
             current_locale = has_unique_locale? ? locale.to_sym : I18n.locale
-            return puret_attributes[current_locale][attribute] if !puret_attributes[current_locale][attribute].nil?
+            attributes = puret_attributes.fetch(current_locale, {})[attribute]
+            return attributes if attributes.present?
             return if new_record?
 
             # Lookup chain:
@@ -106,7 +108,7 @@ module Puret
 
       # attributes are stored in @puret_attributes instance variable via setter
       def puret_attributes
-        @puret_attributes ||= Hash.new { |hash, key| hash[key] = {} }
+        @puret_attributes ||= Hash.new
       end
 
       def reload(options = nil)

--- a/lib/puret/active_record_extensions.rb
+++ b/lib/puret/active_record_extensions.rb
@@ -34,8 +34,8 @@ module Puret
           define_method attribute do
             # return previously setted attributes if present
             current_locale = has_unique_locale? ? locale.to_sym : I18n.locale
-            attributes = puret_attributes.fetch(current_locale, {})[attribute]
-            return attributes if attributes.present?
+            value = puret_attributes.fetch(current_locale, {})[attribute]
+            return value unless value.nil?
             return if new_record?
 
             # Lookup chain:

--- a/test/puret_test.rb
+++ b/test/puret_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 describe 'puret' do
   before do
     setup_db
+    I18n.config.available_locales = [:de, :en, :sv]
     I18n.locale = I18n.default_locale = :en
     Post.create(:title => 'English title')
   end

--- a/test/puret_test.rb
+++ b/test/puret_test.rb
@@ -133,4 +133,13 @@ describe 'puret' do
   it 'model should provide attribute_before_type_cast' do
     assert_equal Post.first.title, Post.first.title_before_type_cast
   end
+
+  it 'does not try to create extra empty translations when loaded with a different locale and updated' do
+    I18n.locale = :de
+    post = Post.last
+    translations_before = post.translations.to_a
+    post.update!(position: 0)
+    translations_after = post.translations.to_a
+    assert_equal translations_after, translations_before
+  end
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,5 +1,6 @@
 ActiveRecord::Schema.define(:version => 1) do
   create_table :posts do |t|
+    t.integer :position # example of untranslated field
     t.timestamps
   end
 


### PR DESCRIPTION
### Context

Card: https://jobteaser.atlassian.net/browse/KS-392

When you load a pureted record with a different locale (e.g. `de`) than it was created (e.g. `en`), and you try to update a non-puret field on that object, puret adds a new empty hash `{ :de => {} }` to the `puret_attributes` of the object. That's because of the side-effectful init of puret_attributes (`@puret_attributes ||= Hash.new { |hash, key| hash[key] = {} }` 😞 

That causes the `#update_translations!` after_save hook to try and save that empty new de translation. If the AR class for the translation has a `presence` validation for some fields, it just blows up. If it doesn't, it goes on to save an empty translation record.

### Change

- Stop initializing puret attributes with the `Hash.new { |h, k| h[k] = {} }` trick that creates a key/val with an empty Hash even on simple reads. Instead, only add the empty hash for the new key when needed on write to puret_attributes.
- Also a couple of fixes to run the specs and bundle install.

### Considerations

- This may fix other bugs beyond the one I was chasing. For instance this one [[Slack](https://jobteaser.slack.com/archives/CB2RB1DLM/p1571154612022700)][[JIRA](https://jobteaser.atlassian.net/browse/JS-328)] looks very similar cc @rbellec 
- We also plan on retiring puret altogether. @papa-cool has an alternative to replace it with (localization/from_table). We may or may not want to merge this first, depending on the kind of time we think we need to remove puret.